### PR TITLE
4.1.0 Исправил JsonCFG.importInifile(), в нем были обращения к функци…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Вернуть класс IniCFG
 
 #### Get-AvvClass
-#### ConvertJSONToHash
+#### ConvertPSCustomObject-ToHashtable
 #### ConvertFrom-JsonToHashtable TODO НЕ РАБОТАЕТ, ТОЛЬКО первый уровень вложенности.
 #### Get-Version
 #### Get-SupportedClasses

--- a/avvClasses.psd1
+++ b/avvClasses.psd1
@@ -77,7 +77,7 @@
     FunctionsToExport = @(
         'Get-Logger', 'Get-IniCFG', 'Get-AvvClass',
         'Get-IsHashtable', 'Get-InfoModule', 'Get-Version',
-        'ConvertFrom-JsonToHashtable', 'ConvertJSONToHash',
+        'ConvertFrom-JsonToHashtable', 'ConvertFrom-PSCustomObjectToHashtable',
         'IsSupportedClass', 'Get-SupportedClasses', 'Get-ImportedModules',
         'Merge-Hashtable',
         'Get-VerboseSession', 'Set-VerboseSession',

--- a/avvClasses.psm1
+++ b/avvClasses.psm1
@@ -458,14 +458,15 @@ function Get-AvvClass {
     Write-Verbose "$($MyInvocation.InvocationName) EXIT:============================================="
 }
 
-#################### ConvertJSONToHash #########################
+#################### ConvertPSCustomObject-ToHashtable #########################
 # Конвертирует PSCustomObject в Hashtable, включая все вложенные свойства,
 # имеющие тип PSCustomObject
-function ConvertJSONToHash{
+#function ConvertJSONToHash{
+function ConvertFrom-PSCustomObjectToHashtable{
     param(
         [Parameter(Mandatory=$true,Position=0,ValueFromPipeline=$true)]
         [AllowNull()]
-        $root
+        [PSCustomObject] $root
     )
     Write-Verbose "$($MyInvocation.InvocationName) ENTER:============================================="
     $hash = @{};
@@ -475,7 +476,7 @@ function ConvertJSONToHash{
             $obj=$root.$($_);
         if($obj -is [PSCustomObject])
         {
-            $nesthash=ConvertJSONToHash $obj;
+            $nesthash=ConvertFrom-PSCustomObjectToHashtable $obj;
             $hash.add($_,$nesthash);
         }
         else
@@ -629,7 +630,7 @@ function Add-Hashtable {
 function Get-VerboseSession {
     Write-Verbose "$($MyInvocation.InvocationName) ENTER: ======================================================="
     Write-Verbose "$($MyInvocation.InvocationName) EXIT: ======================================================="
-    return $VerbosePreference
+    return $global:VerbosePreference
 }
 
 function Set-VerboseSession {
@@ -640,17 +641,16 @@ function Set-VerboseSession {
         $Value='Disable'
     )
     begin {
-        Write-Verbose "$($MyInvocation.InvocationName)  ENTER: ====================================================="
-        Write-Verbose "$($MyInvocation.InvocationName)  begin: ====================================================="
-        Write-Verbose "Value: $($Value)"
     }
     process {
-        Write-Verbose "$($MyInvocation.InvocationName) process: ==================================================="
         if ($Value -eq 'Enable') {
-            $VerbosePreference = "Continue"
+            $global:VerbosePreference = "Continue"
         } else {
-            $VerbosePreference = "SilentlyContinue"
+            $global:VerbosePreference = "SilentlyContinue"
         }
+        Write-Verbose "$($MyInvocation.InvocationName)  ENTER: ====================================================="
+        Write-Verbose "Value: $($Value)"
+        Write-Verbose "$($MyInvocation.InvocationName) process: ==================================================="
     }
     end {
         Write-Verbose "$($MyInvocation.InvocationName) end: ======================================================="

--- a/classes/avvBase.ps1
+++ b/classes/avvBase.ps1
@@ -273,4 +273,37 @@ class avvBase : Object {
         Write-Verbose "avvBase::copyFrom (Source) EXIT: ============================================="
         return $result
     }
+
+    static [Hashtable] ConvertPSCustomObjectToHashtable([PSCustomObject]$root){
+        Write-Verbose "Class avvBase::ConvertPSCustomObjectToHashtable(root) ENTER: ============================================="
+        Write-Verbose "root ::: $(($root | ConvertTo-Json -Depth 1))"
+        $hash = [ordered]@{};
+        $keys = $root | Get-Member -MemberType NoteProperty | Select-Object -exp Name;
+        if ($null -ne $keys) {
+            Write-Verbose "keys.gettype() ::: $($keys.gettype().Name)"
+        }
+        Write-Verbose "keys.gettype() ::: $($keys)"
+        #$keys | %{
+        $keys | ForEach-Object{
+            Write-Verbose "Текущий элемент из keys ::: $($_)"
+            $obj=$root.$($_);
+            Write-Verbose "Тип текущего элемента из keys ::: $($obj.getType().Name)"
+            Write-Verbose "Значение текущего элемента ::: $($obj)"
+            if($obj -is [PSCustomObject])
+            {
+                #Write-Verbose "Тип текущего элемента из keys ::: [PSCustomObject]"
+                $nesthash=[avvBase]::ConvertPSCustomObjectToHashtable($obj);
+                $hash.add($_,$nesthash);
+            }
+            else
+            {
+                Write-Verbose "Добавить в hash ::: ($($_), $($obj))"
+                $hash.add($_,$obj);
+            }
+        }
+        Write-Verbose "return hash ::: $($hash)"
+        Write-Verbose "Class avvBase::ConvertPSCustomObjectToHashtable(root) EXIT: ============================================="
+        return $hash
+    }
+
 }

--- a/classes/classCFG.ps1
+++ b/classes/classCFG.ps1
@@ -1063,9 +1063,9 @@ class JsonCFG : FileCFG
     }
 
     [Hashtable]
-    importInifile([string]$filename)# : base($filename)
+    importInifile([string]$filename) # : base($filename)
     {
-        Write-Verbose "Class JsonCFG::importInifile(filename) ============================================="
+        Write-Verbose "Class JsonCFG::importInifile($($filename)) ENTER: ============================================="
         Write-Verbose "this: $($this)"
         Write-Verbose "filename: $($filename)"
 
@@ -1076,16 +1076,20 @@ class JsonCFG : FileCFG
             # filename не пустой и не равен '_empty'
             #$majV = $avvVersion.Major;
             $json = (Get-Content -Path $filename -Raw);
+            Write-Verbose "Содержимое файла $($filename) ::: $($json)"
             #$json = ( (Get-Content -Path $filename -Raw) | ConvertFrom-JsonToHashtable -casesensitive );
-            $majV = (Get-Version).PSVersion.Major;
+            #$majV = (Get-Version).PSVersion.Major;
+            $majV = $global:PSVersionTable.PSVersion.Major;
             if ($majV -ge 6) {
                 $iniObj = ( $json | ConvertFrom-Json -AsHashtable);
             }
             else
             {
-                $iniObj = ($json | ConvertFrom-Json | ConvertJsonToHash );
+                #$iniObj = ($json | ConvertFrom-Json | ConvertJsonToHash );
+                $iniObj = [avvBase]::ConvertPSCustomObjectToHashtable(($json | ConvertFrom-Json));
             }
         }
+        Write-Verbose "Class JsonCFG::importInifile($($filename)) EXIT: ============================================="
         return $iniObj;
     }
 


### PR DESCRIPTION
…я avvClasses (Get-Version, ConvertJSONToHash), следовательно импортировался модуль avvClasses. Т.е. в классе появилась зависимость от модуля avvClasses. Теперь на замену Get-Version используется $globl:PSVersionTablel, а вместо ConvertJSONToHash - [avvBase]::ConvertPSCustomObjectToHashtable

avvClasses переименовал ConvertJSONToHash -> ConvertFrom-PSCustomObjectToHashtable Исправил Get-VerboseSession и Set-VerboseSession